### PR TITLE
v0.1.3 updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ When run, MarblesCopier will:
  1. Find an open Marbles On Stream window
  2. Click the button to copy results
  3. Immediately click the close button on the annoying popup
- 4. Paste the results into an already-open notepad window
+ 4. Paste the results into the companion `marblescopier-listener` app that feeds the data into the data entry tool.
 
 To use, run the pre-compiled *.exe under releases (compiled with Aut2Exe) or compile using the below instructions
 

--- a/marblescopier/compile-app.ps1
+++ b/marblescopier/compile-app.ps1
@@ -1,4 +1,4 @@
-$copierAppVersion="0.1.1"
+$copierAppVersion="0.1.2"
 
 Remove-Item -Path build -Recurse -Force -ErrorAction SilentlyContinue
 New-Item -Name build -ItemType Directory | Out-Null

--- a/marblescopier/compile-app.ps1
+++ b/marblescopier/compile-app.ps1
@@ -1,4 +1,4 @@
-$copierAppVersion="0.1.2"
+$copierAppVersion="0.1.3"
 
 Remove-Item -Path build -Recurse -Force -ErrorAction SilentlyContinue
 New-Item -Name build -ItemType Directory | Out-Null

--- a/marblescopier/marblescopier.au3
+++ b/marblescopier/marblescopier.au3
@@ -22,6 +22,8 @@ $windowTitle = "[TITLE:Marbles On Stream; CLASS:UnrealWindow]"
 
 ; Get the current window so we can return focus to it
 $previousWindow = WinGetHandle("[active]")
+; Get the current mouse position so we can put the cursor back where it was
+$originalMousePos = MouseGetPos()
 
 ; Set marbles to be active window
 WinActivate($windowTitle)
@@ -36,7 +38,7 @@ $windowResolution=WinGetClientSize($windowTitle)
 
 If WinActive($windowTitle) Then
 	$copyX = int($windowResolution[0] * 0.2)
-	$copyY = int($windowResolution[1] * 0.12)
+	$copyY = int($windowResolution[1] * 0.1)
 
 	$closeX = int($windowResolution[0] * 0.5)
 	$closeY = int($windowResolution[1] * 0.6)
@@ -45,6 +47,8 @@ If WinActive($windowTitle) Then
 	MouseClick("left",$copyX,$copyY,1,0)
 	; Click close button on popup
 	MouseClick("left",$closeX,$closeY,1,0)
+	; Add spacebar press to try and avoid GUI getting stuck and not recognizing our click(s)
+	send('{SPACE}')
 
 	;Paste into special node.js listener which will communicate to the browser
 	WinActivate("Marbles Race Result Paste Listener")
@@ -53,7 +57,11 @@ If WinActive($windowTitle) Then
 	; Need to use really janky keystrokes to paste into CLI window
 	send('!{SPACE}ep{ENTER}{ENTER}{ENTER}')
 
+	; Re-activate old window
 	WinActivate($previousWindow)
+	; Put mouse cursor back where it was
+	MouseMove($originalMousePos[0],$originalMousePos[1],0)
+
 	; Write data to disk as a backup in case of issue
 	; Get current timestamp
 	$dateTime = _NowCalc()


### PR DESCRIPTION
- Position of the copy to clipboard button moved in new Marbles versions.  Updated coordinates to match.
- Mouse cursor now returns to original position on screen after running the copier
- Attempted fix for stuck close button - press spacebar as well as clicking the button (hard to reproduce issue - may not fully fix the problem)